### PR TITLE
Update civitai.ex to handle .red and others

### DIFF
--- a/lib/philomena_proxy/scrapers/civitai.ex
+++ b/lib/philomena_proxy/scrapers/civitai.ex
@@ -6,8 +6,8 @@ defmodule PhilomenaProxy.Scrapers.Civitai do
 
   @behaviour Scraper
 
-  @post_regex ~r|\Ahttps?://(?:www\.)?civitai\.com/posts/([\d]+)/?|
-  @image_regex ~r|\Ahttps?://(?:www\.)?civitai\.com/images/([\d]+)/?|
+  @post_regex ~r|\Ahttps?://(?:www\.)?civitai\.[a-z0-9.-]+/posts/([\d]+)/?|
+  @image_regex ~r|\Ahttps?://(?:www\.)?civitai\.[a-z0-9.-]+/images/([\d]+)/?|
   @url_regex ~r|(https://image\.civitai\.com/\w+/[0-9a-f\-]+)/.*|
 
   @spec can_handle?(URI.t(), String.t()) :: boolean()


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Tantabus and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

* [✅] I understand all of the above

---

Updates civitai scraper to accept TLDs other than .com after their split into .red / .green / .mauve or whatever comes next.